### PR TITLE
Fix PHP warning on methods incompatible

### DIFF
--- a/question_types/quiz_question/quiz_question.core.inc
+++ b/question_types/quiz_question/quiz_question.core.inc
@@ -774,7 +774,7 @@ abstract class QuizQuestionResponse {
    * @return
    *  Validate function as a string, or FALSE if no validate function
    */
-  public function getReportFormValidate() {
+  public function getReportFormValidate(&$element, &$form_state) {
     return FALSE;
   }
 
@@ -861,4 +861,5 @@ abstract class QuizQuestionResponse {
   public function setResultId($result_id) {
     $this->result_id = $result_id;
   }
+
 }


### PR DESCRIPTION
Fix PHP warning: Declaration of LongAnswerResponse::getReportFormValidate() should be compatible with QuizQuestionResponse::getReportFormValidate()

http://drupal.org/node/2351255
